### PR TITLE
Add --mixins flag to enable automatic mixin remapping

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     api libs.srgutils
     implementation libs.bundles.asm
     implementation libs.toml
+    implementation libs.gson
 }
 
 tasks.named('jar', Jar) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -34,6 +34,7 @@ dependencyResolutionManagement.versionCatalogs.register('libs') {
     library 'srgutils',  'net.minecraftforge', 'srgutils'       version '0.6.0'
     library 'powermock', 'org.powermock',      'powermock-core' version '2.0.9'
     library 'toml',      'com.github.jezza',   'toml'           version '1.2-java-8'
+    library 'gson',      'com.google.code.gson', 'gson'         version '2.14.0'
 
     version 'asm', '9.9.1'
     library 'asm',         'org.ow2.asm', 'asm'         versionRef 'asm'

--- a/src/main/java/net/minecraftforge/renamer/Main.java
+++ b/src/main/java/net/minecraftforge/renamer/Main.java
@@ -79,6 +79,7 @@ public class Main {
         OptionSpec<Void> accessTransformersO = parser.accepts("access-transformers", "Enable renaming of access transformers. Located via: FMLAT manifest entry, `META-INF/accesstransformer.cfg` or MANIFEST/mods.toml").availableIf(mapO);
         OptionSpec<Void> legacyATFormatO = parser.accepts("legacy-access-transformers", "If Access Transformers are enabled, will output the transformer in legacy format, which is used in FML <1.6.4").availableIf(mapO);
         OptionSpec<Void> storeO = parser.accepts("store", "Disables compression, this is designed to produce stable output archives no matter what zlib implementation the user has installed");
+        OptionSpec<Void> mixinsO = parser.accepts("mixins", "Enable transforming of Mixin related files. Only RefMaps are currently supported.");
         OptionSpec<Void> helpO = parser.accepts("help", "Prints help and exits").forHelp();
 
         OptionSet options;
@@ -170,6 +171,10 @@ public class Main {
             if (options.has(accessTransformersO) || legacy) {
                 log.accept("Rename Access Transformers" +  (legacy ? " (legacy)" : ""));
                 renamer.accessTransformers(legacy);
+            }
+            if (options.has(mixinsO)) {
+                log.accept("Rename Mixins");
+                renamer.mixins();
             }
             builder.add(renamer.build());
         } else {

--- a/src/main/java/net/minecraftforge/renamer/api/Transformer.java
+++ b/src/main/java/net/minecraftforge/renamer/api/Transformer.java
@@ -391,6 +391,14 @@ public interface Transformer {
          */
         Renamer accessTransformers(boolean legacyFormat);
 
+        /**
+         * Enables renaming of Mixin related files.
+         * Currently only refmaps are supported. It is possible to support inherited mappings for Mixin features
+         * such as the Shadow annotation. Making the AnnotationProcessor's extra mappings file unneeded.
+         * However this would require documenting each feature that would require inheritance.
+         */
+        Renamer mixins();
+
         Factory build();
     }
 }

--- a/src/main/java/net/minecraftforge/renamer/internal/EnhancedRemapper.java
+++ b/src/main/java/net/minecraftforge/renamer/internal/EnhancedRemapper.java
@@ -97,7 +97,7 @@ class EnhancedRemapper extends Remapper {
         return lst.get(0).getMapped();
     }
 
-    private final String naive(String value) {
+    final String naive(String value) {
         return this.naiveSrgMap == null ? value : this.naiveSrgMap.getOrDefault(value, value);
     }
 

--- a/src/main/java/net/minecraftforge/renamer/internal/MixinRenamer.java
+++ b/src/main/java/net/minecraftforge/renamer/internal/MixinRenamer.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -22,14 +21,13 @@ import org.jetbrains.annotations.Nullable;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.internal.LinkedTreeMap;
-
 import net.minecraftforge.renamer.api.Transformer;
 
 class MixinRenamer implements Transformer {
     private static final String MANIFEST_NAME = "META-INF/MANIFEST.MF";
     private static final Attributes.Name MIXIN_CONFIGS = new Attributes.Name("MixinConfigs");
     private static final Gson GSON = new GsonBuilder()
+        .disableHtmlEscaping()
         .setPrettyPrinting()
         .create();
 

--- a/src/main/java/net/minecraftforge/renamer/internal/MixinRenamer.java
+++ b/src/main/java/net/minecraftforge/renamer/internal/MixinRenamer.java
@@ -143,7 +143,7 @@ final class MixinRenamer implements Transformer {
        //public @Nullable Map<String, Map<String, Map<String, String>>> data;
     }
 
-    private static class MemberInfo {
+    private static final class MemberInfo {
         private final String owner;
         private final String name;
         private final String quantifier;

--- a/src/main/java/net/minecraftforge/renamer/internal/MixinRenamer.java
+++ b/src/main/java/net/minecraftforge/renamer/internal/MixinRenamer.java
@@ -23,7 +23,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import net.minecraftforge.renamer.api.Transformer;
 
-class MixinRenamer implements Transformer {
+final class MixinRenamer implements Transformer {
     private static final String MANIFEST_NAME = "META-INF/MANIFEST.MF";
     private static final Attributes.Name MIXIN_CONFIGS = new Attributes.Name("MixinConfigs");
     private static final Gson GSON = new GsonBuilder()

--- a/src/main/java/net/minecraftforge/renamer/internal/MixinRenamer.java
+++ b/src/main/java/net/minecraftforge/renamer/internal/MixinRenamer.java
@@ -100,7 +100,7 @@ class MixinRenamer implements Transformer {
         return ResourceEntry.create(resource.getName(), resource.getTime(), json.getBytes(StandardCharsets.UTF_8));
     }
 
-    private @Nullable String[] findConfigs(Entry entry) {
+    private String @Nullable [] findConfigs(Entry entry) {
         try {
             Manifest mf = new Manifest(new ByteArrayInputStream(entry.getData()));
             String value = (String)mf.getMainAttributes().get(MIXIN_CONFIGS);

--- a/src/main/java/net/minecraftforge/renamer/internal/MixinRenamer.java
+++ b/src/main/java/net/minecraftforge/renamer/internal/MixinRenamer.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright (c) Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+package net.minecraftforge.renamer.internal;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+
+import org.jetbrains.annotations.Nullable;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.internal.LinkedTreeMap;
+
+import net.minecraftforge.renamer.api.Transformer;
+
+class MixinRenamer implements Transformer {
+    private static final String MANIFEST_NAME = "META-INF/MANIFEST.MF";
+    private static final Attributes.Name MIXIN_CONFIGS = new Attributes.Name("MixinConfigs");
+    private static final Gson GSON = new GsonBuilder()
+        .setPrettyPrinting()
+        .create();
+
+    private final Set<String> refmaps = new HashSet<>();
+    private final Consumer<String> logger;
+    private final EnhancedRemapper remapper;
+
+    MixinRenamer(Consumer<String> logger, EnhancedRemapper remapper) {
+        this.logger = logger;
+        this.remapper = remapper;
+    }
+
+    boolean isTarget(String entry) {
+        return this.refmaps.contains(entry);
+    }
+
+    @Override
+    public void preprocess(Map<String, Entry> entries) {
+        Entry entry = entries.get(MANIFEST_NAME);
+        if (entry == null) // No Manifest, so no configs.
+            return;
+
+        String[] cfgs = findConfigs(entries.get(MANIFEST_NAME));
+        if (cfgs == null)
+            return;
+
+        for (String cfg : cfgs) {
+            entry = entries.get(cfg);
+            if (entry == null) {
+                logger.accept("Missing mixin config: " + cfg);
+                continue;
+            }
+
+            String refmap = findRefMap(entry);
+            if (refmap != null)
+                refmaps.add(refmap);
+        }
+    }
+
+    @Override
+    public ResourceEntry process(ResourceEntry resource) {
+        if (!refmaps.contains(resource.getName()))
+            return resource;
+
+        Refmap refmap = null;
+        try (Reader reader = new InputStreamReader(new ByteArrayInputStream(resource.getData()))) {
+            refmap = GSON.fromJson(reader, Refmap.class);
+        } catch (IOException e) {
+            logger.accept("Failed to parse Mixin Refmap " + resource.getName() + ": " + e);
+            return resource;
+        }
+
+        if (refmap.mappings == null || refmap.mappings.isEmpty())
+            return resource;
+
+        Map<String, Map<String, String>> output = new LinkedHashMap<>(refmap.mappings.size());
+        for (Map.Entry<String, Map<String, String>> mixin : refmap.mappings.entrySet()) {
+            Map<String, String> _new = new LinkedHashMap<>(mixin.getValue().size());
+            output.put(mixin.getKey(), _new);
+
+            for (Map.Entry<String, String> entry : mixin.getValue().entrySet()) {
+                MemberInfo old = MemberInfo.parse(entry.getValue());
+                MemberInfo mapped = old.map(this.remapper);
+                _new.put(entry.getKey(), mapped.toString());
+            }
+        }
+
+        refmap.mappings = output;
+        String json = GSON.toJson(refmap);
+        return ResourceEntry.create(resource.getName(), resource.getTime(), json.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private @Nullable String[] findConfigs(Entry entry) {
+        try {
+            Manifest mf = new Manifest(new ByteArrayInputStream(entry.getData()));
+            String value = (String)mf.getMainAttributes().get(MIXIN_CONFIGS);
+            return value == null ? null : value.split(",");
+        } catch (IOException e) {
+            logger.accept("Failed to parse manifest: " + e);
+            return null;
+        }
+    }
+
+    private @Nullable String findRefMap(Entry entry) {
+        try (Reader reader = new InputStreamReader(new ByteArrayInputStream(entry.getData()))) {
+            MixinConfig cfg = GSON.fromJson(reader, MixinConfig.class);
+            return cfg.refmap;
+        } catch (IOException e) {
+            logger.accept("Failed to parse Mixin Config " + entry.getName() + ": " + e);
+            return null;
+        }
+    }
+
+    private static class MixinConfig {
+        /*
+         * I could read these values, and then parse the mixins themselves to fully remap things.
+         * But that would require special casing all mixin annotations and keeping up to date on them
+         * Which is a much bigger task then I want to do right now.
+         * If someone DID want to tackle that, I have most of the logic done in Srg2Source
+         * https://github.com/MinecraftForge/Srg2Source/tree/master/src/main/java/net/minecraftforge/srg2source/mixin
+        @SerializedName("package")
+        public String mixinPackage;
+        public List<String> mixins;
+        public List<String> client;
+        public List<String> server;
+        */
+        public String refmap;
+    }
+
+    private static class Refmap {
+       public Map<String, Map<String, String>> mappings;
+       // This might be useful information, but for the current use case, we just nuke this info
+       //public @Nullable Map<String, Map<String, Map<String, String>>> data;
+    }
+
+    private static class MemberInfo {
+        private final String owner;
+        private final String name;
+        private final String quantifier;
+        private final String desc;
+        private final String tail;
+
+        private final String asString;
+
+        private MemberInfo(String owner, String name, String quantifier, String desc, String tail) {
+            this.owner = owner;
+            this.name = name;
+            this.quantifier = quantifier;
+            this.desc = desc;
+            this.tail = tail;
+
+            StringBuilder buf = new StringBuilder();
+            if (this.owner != null)
+                buf.append('L').append(this.owner).append(';');
+            if (this.name != null)
+                buf.append(this.name);
+            if (this.quantifier != null)
+                buf.append(this.quantifier);
+            if (this.desc != null) {
+                if (this.desc.charAt(0) != '(')
+                    buf.append(':');
+                buf.append(this.desc);
+            }
+            if (this.tail != null)
+                buf.append(this.tail);
+            this.asString = buf.toString();
+        }
+
+        @Override
+        public String toString() {
+            return this.asString;
+        }
+
+        private MemberInfo map(EnhancedRemapper remapper) {
+            String owner = this.owner == null ? null : remapper.map(this.owner);
+
+            String name = null;
+            if (this.name != null) {
+                // No owner, means we need to do the 'naive' srg lookup
+                if (this.owner == null) {
+                    name = remapper.naive(this.name);
+                } else {
+                    if (this.desc != null && this.desc.charAt(0) == '(')
+                        name = remapper.mapMethodName(this.owner, this.name, this.desc);
+                    else
+                        name = remapper.mapFieldName(this.owner, this.name, this.desc);
+                }
+            }
+
+            String desc = null;
+            if (this.desc != null)
+                desc = this.desc.charAt(0) == '(' ? remapper.mapMethodDesc(this.desc) : remapper.mapDesc(this.desc);
+
+            return new MemberInfo(owner, name, this.quantifier, desc, this.tail);
+        }
+
+        private static MemberInfo parse(final String input) {
+            String owner = null;
+            String name = input.replaceAll("\\s", "");
+            String quantifier = null;
+            String desc = null;
+            String tail = null;
+
+            // Find tail, I think this is just legacy, but support it anyways
+            int pos = name.indexOf("->");
+            if (pos > -1) {
+                tail = name.substring(pos);
+                name = name.substring(0, pos);
+            }
+
+            // Find the desc, can be either a field with : or a normal method desc
+            pos = name.lastIndexOf(':');
+            if (pos != -1) { // Field name:desc
+                desc = name.substring(pos + 1);
+                name = name.substring(0, pos);
+            } else {
+                pos = name.lastIndexOf('(');
+                if (pos != -1) {
+                    desc = name.substring(pos);
+                    name = name.substring(0, pos);
+                }
+            }
+
+            pos = name.lastIndexOf('.');
+            if (pos != -1) { // Legacy format: owner.name
+                owner = name.substring(0, pos).replace('.', '/');
+                name = name.substring(pos + 1);
+            } else if (name.charAt(0) == 'L') { // Modern format: Lowner;name
+                pos = name.indexOf(';');
+                if (pos != -1) {
+                    owner = name.substring(1, pos).replace('.', '/');
+                    name = name.substring(pos + 1);
+                }
+            }
+
+            if (owner == null) { // Possibly a full class name
+                name = name.replace('.', '/');
+                if (name.indexOf('/') != -1) {
+                    owner = name;
+                    name = "";
+                }
+            }
+
+            // Pull out the qualifier if there is one
+            if (!name.isEmpty()) {
+                char last = name.charAt(name.length() - 1);
+                if (last == '*' || last == '+') {
+                    quantifier = name.substring(name.length() - 1);
+                    name = name.substring(0, name.length() - 1);
+                } else {
+                    pos = name.indexOf('{');
+                    if (pos != -1) {
+                        quantifier = name.substring(pos);
+                        name = name.substring(0, pos);
+                    }
+                }
+            }
+
+            if (name.isEmpty())
+                name = null;
+
+            return new MemberInfo(owner, name, quantifier, desc, tail);
+        }
+    }
+}
+

--- a/src/main/java/net/minecraftforge/renamer/internal/RenamingTransformer.java
+++ b/src/main/java/net/minecraftforge/renamer/internal/RenamingTransformer.java
@@ -23,6 +23,7 @@ import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 
+import org.jetbrains.annotations.Nullable;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.commons.ClassRemapper;
@@ -48,6 +49,7 @@ public class RenamingTransformer implements Transformer {
     private final boolean legacyForamt;
     private final Consumer<String> logger;
     private final Set<String> atPaths = new HashSet<>();
+    private final @Nullable MixinRenamer mixins;
 
     private RenamingTransformer(Transformer.Context ctx, Builder builder) {
         this.collectAbstractParams = builder.collectAbstractParameters;
@@ -55,6 +57,7 @@ public class RenamingTransformer implements Transformer {
         this.legacyForamt = builder.legacyFormat;
         this.logger = ctx.getLog();
         this.remapper = new EnhancedRemapper(ctx.getClassProvider(), builder.map, this.logger, builder.naiveSrg);
+        this.mixins = builder.mixins ? new MixinRenamer(this.logger, this.remapper) : null;
     }
 
     @Override
@@ -103,6 +106,8 @@ public class RenamingTransformer implements Transformer {
                 }
             }
         }
+        if (this.mixins != null)
+            this.mixins.preprocess(entries);
     }
 
     @Override
@@ -128,6 +133,9 @@ public class RenamingTransformer implements Transformer {
 
         if (this.atPaths.contains(entry.getName()))
             return renameAccessTransformer(entry);
+
+        if (this.mixins != null && this.mixins.isTarget(entry.getName()))
+            return this.mixins.process(entry);
 
         return entry;
     }
@@ -210,6 +218,7 @@ public class RenamingTransformer implements Transformer {
         private boolean collectAbstractParameters = false;
         private boolean renameAts = false;
         private boolean legacyFormat = false;
+        private boolean mixins = false;
 
         public Builder(IMappingFile map) {
             this.map = map;
@@ -236,6 +245,12 @@ public class RenamingTransformer implements Transformer {
         public Builder accessTransformers(boolean legacyFormat) {
             this.renameAts = true;
             this.legacyFormat = legacyFormat;
+            return this;
+        }
+
+        @Override
+        public Builder mixins() {
+            this.mixins = true;
             return this;
         }
     }


### PR DESCRIPTION
Currently only supports refmaps.json
This removes the need for the runtime `mixin.env.remapRefMap` and `mixin.env.refMapRemappingFile` flags which are poorly documented and only support slow SRG [string replacements](https://github.com/SpongePowered/Mixin/blob/4053421aa10aaac6127d969028a29c94fe3054f6/src/main/java/org/spongepowered/asm/mixin/refmap/RemappingReferenceMapper.java#L173). As well as only supporting [SRG format](https://github.com/SpongePowered/Mixin/blob/4053421aa10aaac6127d969028a29c94fe3054f6/src/main/java/org/spongepowered/asm/mixin/refmap/RemappingReferenceMapper.java#L235). This can mess up if the mappings file contains anything that would get simple replaced when it shouldn't. Such as during obf->mcp renaming where fields are often called 'a'. 
Example: 
`FD: A/a Client/field`
`a:Ljava/lang/String;` -> `field:Ljfieldvfield/lfieldang/String;`
This is a concerned noted in its [javadocs](https://github.com/SpongePowered/Mixin/blob/4053421aa10aaac6127d969028a29c94fe3054f6/src/main/java/org/spongepowered/asm/mixin/refmap/RemappingReferenceMapper.java#L43) which shouldn't be an issue in versions that use SRG names. However I think it's better to address this during the remapping to prevent this issue in the first place.

Now there is a much larger task of actually bypassing the need for the AnnotationProcessor at all.
This would require going through all the possible paths that the AP outputs 'extra' mappings for. Which is a lot. I believe I have found all the cases in my work on [Srg2Source](https://github.com/MinecraftForge/Srg2Source/tree/master/src/main/java/net/minecraftforge/srg2source/mixin). However it would be better if there was some official unit test set. Or if someone else could double check my work.

This Pr is mainly opened as a sanity check, I need someone who actually uses a dep with Mixins to test this. And as an opening to talk about the specifics of going full ham into finding the inheritance info ourselves for mixins.

Note: This adds a dependency on gson, which adds ~200kb(from 450kb) to the jar.